### PR TITLE
Quicker resolve

### DIFF
--- a/libexec/vars.sh
+++ b/libexec/vars.sh
@@ -41,6 +41,49 @@ value_of() {
     var_val "$1"
 }
 
+# This is an expansion safe envsubst implementation in pure-shell and inspired
+# by https://stackoverflow.com/a/40167919. It uses eval in a controlled-manner
+# to avoid side-effects.
+# shellcheck disable=SC2120
+_envsubst() {
+    if [ "$#" -gt "0" ]; then
+        printf %s\\n "$1" | _envsubst
+    else
+        # Prepare a sed script that will replace all occurrences of the known
+        # environment variables by their value
+        _sed=$(mktemp)
+        while IFS='=' read -r var val; do
+            for separator in ! ~ ^ % \; /; do
+                if ! printf %s\\n "$val" | grep -qo "$separator"; then
+                    printf 's%s\x04%s%s%s%sg\n' \
+                        "$separator" "$var" "$separator" "$val" "$separator" >> "$_sed"
+                    break
+                fi
+            done
+        done <<EOF
+$(env|grep -E '^[0-9[:upper:]][0-9[:upper:]_]*=')
+EOF
+
+        while IFS= read -r line || [ -n "$line" ]; do  # Read, incl. non-empty last line
+            # Transpose all chars that could trigger an expansion to control
+            # characters, and perform expansion using the script above for pure
+            # variable substitutions. Once done, transpose only the ${ back to
+            # what they should (and escape the double quotes)
+            _line=$(printf %s\\n "$line" |
+                        tr '`([$' '\1\2\3\4' |
+                        sed -f "$_sed" |
+                        sed -e 's/\x04{/${/g' -e 's/"/\\\"/g')
+            # At this point, eval is safe, since the only expansion left is for
+            # ${} contructs. Perform the eval and convert back the control
+            # characters to the real chars.
+            eval "printf '%s\n' \"$_line\"" | tr '\1\2\3\4' '`([$'
+        done
+
+        # Get rid of the temporary sed script
+        rm -f "$_sed"
+    fi
+}
+
 # Resolve the value of % enclosed variables with their content in the incoming
 # stream. Do this only for "our" variables, i.e. the ones from this script.
 resolve() {
@@ -49,14 +92,11 @@ resolve() {
   set --
   # Construct a set of -e sed expressions. Build these onto the only array that
   # we have, i.e. the one to carry incoming arguments.
-  while IFS= read -r line; do
-    # Get the name of the variable, i.e. everything in uppercase before the
-    # equal sign printed out by set.
-    var=$(printf %s\\n "$line" | grep -Eo '^[A-Z0-9_]+')
+  while IFS='=' read -r var val; do
     # remove the leading and ending quotes out of the value coming from set, we
     # could run through eval here, but it'll be approx as many processes (so no
     # optimisation possible)
-    val=$(printf %s\\n "$line" | var_val "$var")
+    val=$(printf %s\\n "$val" | unquote)
     # Construct a sed expression using a non-printable separator (the vertical
     # tab) so we minimise the risk of its presence in the value.
     set -- -e "s%${var}%${val}g" "$@"


### PR DESCRIPTION
Resolves the value of environment variables quicker, at the expense of possible bugs on lines containing several `=` signs in the environment