### PR TITLE
Add support for bindmounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,16 +282,16 @@ container at its creation (the `COMMAND` from a Dockerfile). Pass the option
 Provided the first argument after the (optional) `--` is `XXX`, it will be
 understood as follows:
 
-- If a file called `Dockerfile.XXX`, or `XXX.Dockerfile`, or `XXX.df` is found
++ If a file called `Dockerfile.XXX`, or `XXX.Dockerfile`, or `XXX.df` is found
   under the configuration path `DEW_CONFIG_PATH`, that file will be used to
   build a local Docker image called `github.com/efrecon/dew/XXX` -- the prefix
   is actually controlled by `DEW_NAMESPACE`. `dew` will rebuild a new image only
   whenever a change has been detected on the Dockerfile.
-- If a file called `XXX` or `XXX.env` is found under the configuration path
++ If a file called `XXX` or `XXX.env` is found under the configuration path
   `DEW_CONFIG_PATH`, that file will be used to set any of the environment
   variables described below. Note that it is possible to combine this behaviour
   with the Dockerfile behaviour above.
-- If none of the above was true, `XXX` is understood as the name of a local or
++ If none of the above was true, `XXX` is understood as the name of a local or
   remote Docker image.
 
 ## Environment Variables
@@ -335,7 +335,7 @@ container will run under a user with the same user and group identifiers as the
 ones of the calling user. In addition, in interactive containers, the user
 inside the container will be given the same `HOME` directory as the original
 user, albeit empty (except perhaps for the current path, see
-[`DEW_MOUNT`](#dewmount)). Impersonation works by running the container as
+[`DEW_MOUNT`](#dew_mount)). Impersonation works by running the container as
 `root`, but injecting an impersonation script that will setup a minimal
 environment inside the container before becoming to relevant user and group.
 
@@ -382,6 +382,25 @@ other words:
   the container, and makes the current directory the working directory. This
   enables the container to access all files and directories contained in the
   parent directory.
+
+### `DEW_MOUNTS`
+
+This variable should contain a space-separated list of bindmount specifications,
+from the host into the container. Each specification is modelled after the `-v`
+[option][mount-vol] of the Docker client. Mount specifications are separated by
+the colon `:` sign and will contain in order:
+
++ The source directory on the host.
++ The destination directory into the container. When empty, this will
+  automatically be initialised the the same as the source directory on the host.
++ A list of options, blindly passed to the `-v` option. When running with
+  `podman`, the `Z` option will automatically be added.
+
+Note that in the content of this variable, any string named after one of the
+documented [variables](#variables-accessible-to-resolution), but surrounded by
+`%`, e.g. `%DEW_SHELL%`, will be replaced by the value of that variable.
+
+  [mount-vol]: https://docs.docker.com/reference/cli/docker/container/run/#volume
 
 ### `DEW_OPTS`
 
@@ -489,7 +508,7 @@ documented [variables](#variables-accessible-to-resolution), but surrounded by
 ### `DEW_INJECT_ARGS`
 
 This variable contains arguments that are blindly passed to the
-[injected](#dewinject) command at the time of image creation. This facilitates
+[injected](#dew_inject) command at the time of image creation. This facilitates
 the reuse of the same injected command, with varying arguments. You could, for
 example, reuse a command that performs generic package installation and give it
 varying packages for the implementation of a container.
@@ -528,7 +547,7 @@ evicted from the cache. The default is 41 days.
 ## Variables Accessible to Resolution
 
 The variables accessible are all the variables starting with `DEW_` and
-described in the section [above][#environment-variables]. In addition, it is
+described in the section [above](#environment-variables). In addition, it is
 possible to use, when relevant:
 
 + `DEW_CONFIGDIR`: The directory hosting the `.env` configuration file.
@@ -591,3 +610,8 @@ to be installed on the host system.
 For a short time period, `dew` supported a `DEW_NETWORK` environment variable
 (and corresponding `--network` option). This has been removed in favour of the
 `DEW_FEATURES` environment variable.
+
+A number of `.env` files contain references to `DEW_OPTS` for mounting extra
+directories/files into the container. It is usually a better idea to use the
+`DEW_MOUNTS` variable instead, as it will be aware of the differences between
+`docker` and `podman`.

--- a/config/act.env
+++ b/config/act.env
@@ -4,4 +4,4 @@ DEW_INTERACTIVE=on
 DEW_IMPERSONATE=off
 DEW_COMMENT="You probably want to run with options: -b -P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-latest"
 DEW_PATHS="${HOME}/.actrc"
-DEW_OPTS="-v $HOME/.actrc:$HOME/.actrc"
+DEW_MOUNTS="$HOME/.actrc"

--- a/config/aws.env
+++ b/config/aws.env
@@ -6,4 +6,4 @@ DEW_SOCK=
 DEW_INJECT=%DEW_CONFIGDIR%/aws.sh
 DEW_SHELL=aws
 DEW_PATHS="$HOME/.aws:d"
-DEW_OPTS="-v $HOME/.aws:/root/.aws"
+DEW_MOUNTS="$HOME/.aws:/root/.aws"

--- a/config/awslocal.env
+++ b/config/awslocal.env
@@ -5,4 +5,4 @@ DEW_DOCKER=0
 DEW_SOCK=
 DEW_PATHS="$HOME/.aws:d"
 DEW_SHELL=awslocal
-DEW_OPTS="-v %DEW_CONFIGDIR%/awslocal.sh:/usr/local/bin/awslocal:ro -v $HOME/.aws:/root/.aws"
+DEW_MOUNTS="%DEW_CONFIGDIR%/awslocal.sh:/usr/local/bin/awslocal:ro $HOME/.aws:/root/.aws"

--- a/config/az.env
+++ b/config/az.env
@@ -3,4 +3,4 @@ DEW_IMAGE=mcr.microsoft.com/azure-cli
 DEW_SHELL=az
 DEW_DOCKER=0
 DEW_PATHS="$HOME/.azure:d"
-DEW_OPTS="-v $HOME/.azure:$HOME/.azure"
+DEW_MOUNTS="$HOME/.azure"

--- a/config/binenv.env
+++ b/config/binenv.env
@@ -1,8 +1,7 @@
 # One binary to rule them all. Manage all those pesky binaries (kubectl, helm,
 # terraform, ...) easily. https://github.com/devops-works/binenv
 DEW_IMAGE=ghcr.io/efrecon/binenv:v0.12.0
-# This will not work properly if the directory does not already exist before
-# dew is run
-DEW_OPTS="-v $HOME/.config/binenv:$HOME/.config/binenv"
+DEW_PATHS="$HOME/.config/binenv"
+DEW_MOUNTS="$HOME/.config/binenv"
 DEW_DOCKER=0
 DEW_SOCK=

--- a/config/bun.env
+++ b/config/bun.env
@@ -3,5 +3,6 @@
 DEW_IMAGE=oven/bun
 DEW_SHELL=bun
 DEW_PATHS="$HOME/.npm:d"
-DEW_OPTS="-v $HOME/.npm:$HOME/.npm --ulimit memlock=-1:-1"
+DEW_OPTS="--ulimit memlock=-1:-1"
+DEW_MOUNTS="$HOME/.npm"
 DEW_IMPERSONATE=minimal

--- a/config/cdk.env
+++ b/config/cdk.env
@@ -5,4 +5,4 @@ DEW_DOCKER=1
 DEW_INJECT=%DEW_CONFIGDIR%/cdk.sh
 DEW_SHELL=cdk
 DEW_PATHS="$HOME/.npm:d $HOME/.aws:d $HOME/.gitconfig:f $HOME/.cdk.json:f:%DEW_CONFIGDIR%/cdk.json $HOME/.cdk/cache:d"
-DEW_OPTS="-v $HOME/.npm:$HOME/.npm -v $HOME/.aws:$HOME/.aws:ro -v $HOME/.gitconfig:$HOME/.gitconfig:ro -v $HOME/.cdk.json:$HOME/.cdk.json:ro -v $HOME/.cdk:$HOME/.cdk"
+DEW_MOUNTS="$HOME/.npm $HOME/.aws::ro $HOME/.gitconfig::ro $HOME/.cdk.json::ro $HOME/.cdk"

--- a/config/cdklocal.env
+++ b/config/cdklocal.env
@@ -5,4 +5,4 @@ DEW_DOCKER=1
 DEW_INJECT=%DEW_CONFIGDIR%/cdk.sh
 DEW_SHELL=cdklocal
 DEW_PATHS="$HOME/.npm:d $HOME/.aws:d $HOME/.gitconfig:f $HOME/.cdk.json:f:%DEW_CONFIGDIR%/cdk.json $HOME/.cdk/cache:d"
-DEW_OPTS="-v $HOME/.npm:$HOME/.npm -v $HOME/.aws:$HOME/.aws:ro -v $HOME/.gitconfig:$HOME/.gitconfig:ro -v $HOME/.cdk.json:$HOME/.cdk.json:ro -v $HOME/.cdk:$HOME/.cdk"
+DEW_MOUNTS="$HOME/.npm $HOME/.aws::ro $HOME/.gitconfig::ro $HOME/.cdk.json::ro $HOME/.cdk"

--- a/config/dotnet.env
+++ b/config/dotnet.env
@@ -5,6 +5,6 @@ DEW_DOCKER=0
 # https://docs.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior#config-file-locations-and-uses
 DEW_PATHS="$HOME/.nuget/NuGet:d"
 DEW_XDG=NuGet
-DEW_OPTS="-v $HOME/.nuget/NuGet:$HOME/.nuget/NuGet"
+DEW_MOUNTS="$HOME/.nuget/NuGet"
 
 DEW_SHELL=dotnet

--- a/config/golang.env
+++ b/config/golang.env
@@ -5,4 +5,4 @@ DEW_PATHS="$HOME/go/bin:d $HOME/go/pkg:d $HOME/go/src:d $HOME/.cache/go-build:d"
 # Map the minimal environment to /go and $HOME/go. Mapping to /go arranges for
 # the default GOPATH to work, mapping to $HOME/go arranges for when no GOPATH is
 # set, and/or this is already present in the user's GOPATH.
-DEW_OPTS="-v $HOME/go:/go:rw -v $HOME/go:$HOME/go:rw -v $HOME/.cache/go-build:$HOME/.cache/go-build:rw"
+DEW_MOUNTS="$HOME/go:/go $HOME/go:$HOME/go $HOME/.cache/go-build"

--- a/config/helm.env
+++ b/config/helm.env
@@ -1,5 +1,5 @@
 # The package manager for Kubernetes. https://helm.sh/docs/
 DEW_IMAGE=efrecon/helm:v3.7.1
 DEW_XDG=helm
-DEW_OPTS="-v $HOME/.kube/config:$HOME/.kube/config:ro"
+DEW_MOUNTS="$HOME/.kube/config::ro"
 DEW_DOCKER=0

--- a/config/kubectl.env
+++ b/config/kubectl.env
@@ -2,5 +2,5 @@
 # cluster's control plane, using the Kubernetes API.
 # https://kubernetes.io/docs/reference/kubectl/
 DEW_IMAGE=efrecon/kubectl:v1.22.3
-DEW_OPTS="-v $HOME/.kube/config:$HOME/.kube/config:ro"
+DEW_MOUNTS="$HOME/.kube/config::ro"
 DEW_DOCKER=0

--- a/config/npm.env
+++ b/config/npm.env
@@ -4,4 +4,4 @@ DEW_IMAGE=node:18
 DEW_INJECT=%DEW_CONFIGDIR%/npm.sh
 DEW_SHELL=npm
 DEW_PATHS="$HOME/.npm:d"
-DEW_OPTS="-v $HOME/.npm:$HOME/.npm"
+DEW_MOUNTS="$HOME/.npm"

--- a/config/nuget.env
+++ b/config/nuget.env
@@ -8,7 +8,7 @@ DEW_XDG=NuGet
 
 # Force in a nuget.sh companion script to get argument expansion right, together
 # with the additional path for NuGet configuration.
-DEW_OPTS="-v %DEW_CONFIGDIR%/nuget.sh:/usr/local/bin/nuget.sh:ro -v $HOME/.dotnet:$HOME/.dotnet -v $HOME/.nuget/NuGet:$HOME/.nuget/NuGet"
+DEW_MOUNTS="%DEW_CONFIGDIR%/nuget.sh:/usr/local/bin/nuget.sh:ro $HOME/.dotnet $HOME/.nuget/NuGet"
 
 # Force the shell to be the companion script that we have forced into the
 # container using the volume mount above. This will just relay into `dotnet

--- a/config/procs.env
+++ b/config/procs.env
@@ -1,6 +1,6 @@
 # A modern replacement for ps written in Rust. https://github.com/dalance/procs
 DEW_IMAGE=ghcr.io/efrecon/procs:0.9.9
 DEW_SHELL=-
-DEW_OPTS="-v /proc:/proc:ro"
+DEW_MOUNTS="/proc::ro"
 DEW_DOCKER=0
 DEW_SOCK=

--- a/config/rclone.env
+++ b/config/rclone.env
@@ -1,4 +1,4 @@
 # Rclone syncs your files to cloud storage. https://rclone.org/docs/
 DEW_IMAGE=rclone/rclone
 DEW_XDG=rclone
-DEW_OPTS="-v $HOME/.aws:$HOME/.aws:ro"
+DEW_MOUNTS="$HOME/.aws::ro"

--- a/config/sam.env
+++ b/config/sam.env
@@ -5,4 +5,4 @@ DEW_DOCKER=1
 DEW_INJECT=%DEW_CONFIGDIR%/sam.sh
 DEW_SHELL=sam
 DEW_PATHS="$HOME/.aws:d"
-DEW_OPTS="-v $HOME/.aws:/root/.aws"
+DEW_MOUNTS="$HOME/.aws:/root/.aws"

--- a/config/tclsh.env
+++ b/config/tclsh.env
@@ -9,7 +9,7 @@ DEW_IMAGE=efrecon/mini-tcl
 
 # Force in the tclsh.sh companion initialisation entrypoint. The companion
 # arranges for a .tclshrc at the user.
-DEW_OPTS="-v %DEW_CONFIGDIR%/tclsh.sh:/usr/local/bin/tclsh.sh:ro"
+DEW_MOUNTS="%DEW_CONFIGDIR%/tclsh.sh:/usr/local/bin/tclsh.sh:ro"
 
 # Force the shell to be the companion that we have forced into the container
 # using the volume mount above.

--- a/config/terraform.env
+++ b/config/terraform.env
@@ -6,4 +6,4 @@ DEW_SHELL=-
 DEW_DOCKER=0
 DEW_XDG=terraform
 DEW_PATHS="$HOME/.terraformrc $HOME/.terraform.d:d"
-DEW_OPTS="-v $HOME/.terraformrc:$HOME/.terraformrc:ro -v $HOME/.terraform.d:$HOME/.terraform.d:rw"
+DEW_MOUNTS="$HOME/.terraformrc::ro $HOME/.terraform.d"

--- a/config/vcluster.env
+++ b/config/vcluster.env
@@ -3,5 +3,6 @@
 # https://www.vcluster.com/docs/what-are-virtual-clusters
 DEW_IMAGE=efrecon/vcluster:v0.3.0-beta.4
 DEW_XDG=helm
-DEW_OPTS="-v $HOME/.kube/config:$HOME/.kube/config:ro -p 8443:8443"
+DEW_MOUNTS="$HOME/.kube/config::ro"
+DEW_OPTS="-p 8443:8443"
 DEW_DOCKER=0


### PR DESCRIPTION
Add support for bindmounts through new `DEW_MOUNTS` variable. This relays the new `bindmount` function and is aware of `podman` (as opposed to `DEW_OPTS`).

